### PR TITLE
github credentials in environment, and code reorganization

### DIFF
--- a/Commands/Private Gist.tmCommand
+++ b/Commands/Private Gist.tmCommand
@@ -7,43 +7,24 @@
 	<key>command</key>
 	<string>#!/usr/bin/env ruby
 
-require 'net/http'
-require 'uri'
+require ENV['TM_BUNDLE_SUPPORT'] + '/gist.rb'
 
-contents = ENV['TM_SELECTED_TEXT'] || `/usr/bin/env cat "#{ENV['TM_FILEPATH']}"`
-name = ENV['TM_FILENAME'] || 'Uploaded from TextMate'
+if @continue
+  response = Net::HTTP.post_form(URI.parse('http://gist.github.com/api/v1/xml/new'), {
+    "files[#{@name}]" =&gt; @contents,
+    "private" =&gt; true,
+    "login" =&gt; @login,
+    "token" =&gt; @token
+  })
 
-if contents.nil? || contents.strip == ''
-  puts "Error: no content to upload"
-
-else
-  login = `#{ENV['TM_GIT'] || "/usr/bin/env git"} config --global --get github.user`.chomp
-  token = `#{ENV['TM_GIT'] || "/usr/bin/env git"} config --global --get github.token`.chomp
-  
-  if login.nil? || login == ''
-    puts "Error: your github login is not set"
-
-  elsif token.nil? || token == ''
-    puts "Error: your github token is not set"
-
+  if response.body =~ /&lt;repo&gt;(\w+)&lt;\/repo&gt;/xi
+    `echo -n "https://gist.github.com/#{$1}" | pbcopy`  
+    puts "Private Gist URL copied to clipboard" 
   else
-    response = Net::HTTP.post_form(URI.parse('http://gist.github.com/api/v1/xml/new'), {
-      "files[#{name}]" =&gt; contents,
-      "private" =&gt; true,
-      "login" =&gt; login,
-      "token" =&gt; token
-    })
-  
-    if response.body =~ /&lt;repo&gt;(\w+)&lt;\/repo&gt;/xi
-  	  `echo -n "https://gist.github.com/#{$1}" | pbcopy`	
-  	  puts "Private Gist URL copied to clipboard" 
-
-    else
-  	  puts "Error uploading private gist"
-    end
+    puts "Error uploading private gist"
   end
-  
-end</string>
+end
+</string>
 	<key>input</key>
 	<string>selection</string>
 	<key>keyEquivalent</key>

--- a/Commands/Public Gist.tmCommand
+++ b/Commands/Public Gist.tmCommand
@@ -7,42 +7,23 @@
 	<key>command</key>
 	<string>#!/usr/bin/env ruby
 
-require 'net/http'
-require 'uri'
+require ENV['TM_BUNDLE_SUPPORT'] + '/gist.rb'
 
-contents = ENV['TM_SELECTED_TEXT'] || `/usr/bin/env cat "#{ENV['TM_FILEPATH']}"`
-name = ENV['TM_FILENAME'] || 'Uploaded from TextMate'
+if @continue
+  response = Net::HTTP.post_form(URI.parse('http://gist.github.com/api/v1/xml/new'), {
+    "files[#{@name}]" =&gt; @contents,
+    "login" =&gt; @login,
+    "token" =&gt; @token
+  })
 
-if contents.nil? || contents.strip == ''
-  puts "Error: no content to upload"
-
-else
-  login = `#{ENV['TM_GIT'] || "/usr/bin/env git"} config --global --get github.user`.chomp
-  token = `#{ENV['TM_GIT'] || "/usr/bin/env git"} config --global --get github.token`.chomp
-  
-  if login.nil? || login == ''
-    puts "Error: your github login is not set"
-
-  elsif token.nil? || token == ''
-    puts "Error: your github token is not set"
-
+  if response.body =~ /&lt;repo&gt;(\w+)&lt;\/repo&gt;/xi
+    `echo -n "http://gist.github.com/#{$1}" | pbcopy` 
+    puts "Public Gist URL copied to clipboard" 
   else
-    response = Net::HTTP.post_form(URI.parse('http://gist.github.com/api/v1/xml/new'), {
-      "files[#{name}]" =&gt; contents,
-      "login" =&gt; login,
-      "token" =&gt; token
-    })
-  
-    if response.body =~ /&lt;repo&gt;(\w+)&lt;\/repo&gt;/xi
-  	  `echo -n "http://gist.github.com/#{$1}" | pbcopy`	
-  	  puts "Public Gist URL copied to clipboard" 
-
-    else
-	    puts "Error uploading public gist"
-    end
+    puts "Error uploading public gist"
   end
-  
-end</string>
+end
+</string>
 	<key>input</key>
 	<string>selection</string>
 	<key>keyEquivalent</key>

--- a/README.textile
+++ b/README.textile
@@ -6,22 +6,31 @@ h2. Pre-requisites
 
 * Install ruby
 * Configure your "GitHub account":https://github.com/account
-* If for some reason your git binary is in a place that /usr/bin/env cannot locate, then you can set it to a TextMate Shell variable (TM_GIT)
-
+* If for some reason your git binary is in a place that /usr/bin/env cannot locate, then you can set it to a TextMate Shell variable (`TM_GIT`), or add the path its in to `PATH`. For example, if you installed git from MacPorts, you would add `/opt/local/bin:` to the front of `PATH`,
+* add your github username and token to your git config:
 <pre>
-$ git config --global github.user [your username]
-$ git config --global github.token [your token]
+<code>
+  $ git config --global github.user [your username]
+  $ git config --global github.token [your token]
+</code>
+</pre>
+**or** to your shell environment:
+<pre>
+<code>
+  export GITHUB_USER="[your username]"
+  export GITHUB_TOKEN="[your token]"
+</code>
 </pre>
 
 h2. Install
-
 <pre>
+<code>
 mkdir -p ~/Library/Application\ Support/TextMate/Bundles/
 cd ~/Library/Application\ Support/TextMate/Bundles
 git clone git://github.com/ivanvc/gists-tmbundle.git Gists.tmbundle
 osascript -e 'tell app "TextMate" to reload bundles'
+</code>
 </pre>
-
 h2. That's it
 
 * Use ⌘⌥⇧I to create a private gist

--- a/Support/gist.rb
+++ b/Support/gist.rb
@@ -1,0 +1,27 @@
+require 'net/http'
+require 'uri'
+
+git_binary = ENV['TM_GIT'] || "/usr/bin/env git"
+github_config_get = "#{git_binary} config --global --get github"
+
+@login = ENV['GITHUB_USER']  || `#{github_config_get}.user`.chomp
+@token = ENV['GITHUB_TOKEN'] || `#{github_config_get}.token`.chomp
+
+@continue = true
+
+if @login.nil? || @login == ''
+  print "\nError: your github login is not set. See https://github.com/ivanvc/gists-tmbundle for configuration instructions.\n"
+  @continue = false
+end
+if @token.nil? || @token == ''
+  print "\nError: your github token is not set.  See https://github.com/ivanvc/gists-tmbundle for configuration instructions.\n"
+  @continue = false
+end
+
+@contents = ENV['TM_SELECTED_TEXT'] || `/usr/bin/env cat "#{ENV['TM_FILEPATH']}"`
+@name     = ENV['TM_FILENAME']      || 'Uploaded from TextMate'
+
+if @contents.nil? || @contents.strip == ''
+  puts "Error: no content to upload"
+  @continue = false
+end


### PR DESCRIPTION
Here's a patch that reads github credentials from the shell environment if they are there (I don't like to keep mine in my .gitconfig because i have my .gitconfig checked into a public repo[1]).

I've also reorganized the code into a common library.

Let me know what you think!
John

[1]https://github.com/jjb/dotfiles
